### PR TITLE
Extend --keep-doc-comments support

### DIFF
--- a/lib/no_comments/comment_detector.rb
+++ b/lib/no_comments/comment_detector.rb
@@ -5,6 +5,8 @@ module NoComments
     MAGIC_COMMENT_REGEX = /\A#.*\b(?:frozen_string_literal|encoding|coding|warn_indent|fileencoding)\b.*\z/
     TOOL_COMMENT_REGEX = /\A#\s*(?:rubocop|reek|simplecov|coveralls|pry|byebug|noinspection|sorbet|type)\b/
     DOC_COMMENT_REGEX = /\A#\s*@\w+/
+    NODOC_REGEX = /#.*:nodoc:/
+    CLASS_OR_MODULE_REGEX = /\A(?:class|module)\b/
     def magic_comment?(stripped_line)
       stripped_line.match?(MAGIC_COMMENT_REGEX)
     end
@@ -13,8 +15,12 @@ module NoComments
       stripped_line.match?(TOOL_COMMENT_REGEX)
     end
 
-    def documentation_comment?(stripped_line)
-      stripped_line.match?(DOC_COMMENT_REGEX)
+    def documentation_comment?(stripped_line, next_line = nil)
+      return true if stripped_line.match?(DOC_COMMENT_REGEX)
+      return true if stripped_line.match?(NODOC_REGEX)
+      return true if next_line&.match?(CLASS_OR_MODULE_REGEX)
+
+      false
     end
   end
 end

--- a/lib/no_comments/comment_detector.rb
+++ b/lib/no_comments/comment_detector.rb
@@ -5,7 +5,7 @@ module NoComments
     MAGIC_COMMENT_REGEX = /\A#.*\b(?:frozen_string_literal|encoding|coding|warn_indent|fileencoding)\b.*\z/
     TOOL_COMMENT_REGEX = /\A#\s*(?:rubocop|reek|simplecov|coveralls|pry|byebug|noinspection|sorbet|type)\b/
     DOC_COMMENT_REGEX = /\A#\s*@\w+/
-    NODOC_REGEX = /#.*:nodoc:/
+    NODOC_STRING = ":nodoc:"
     CLASS_OR_MODULE_REGEX = /\A(?:class|module)\b/
     def magic_comment?(stripped_line)
       stripped_line.match?(MAGIC_COMMENT_REGEX)
@@ -17,7 +17,7 @@ module NoComments
 
     def documentation_comment?(stripped_line, next_line = nil)
       return true if stripped_line.match?(DOC_COMMENT_REGEX)
-      return true if stripped_line.match?(NODOC_REGEX)
+      return true if stripped_line.include?(NODOC_STRING)
       return true if next_line&.match?(CLASS_OR_MODULE_REGEX)
 
       false

--- a/no_comments.gemspec
+++ b/no_comments.gemspec
@@ -22,12 +22,12 @@ leaving your code clean and ready for deployment."
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  require "open3"
   gemspec = File.basename(__FILE__)
-  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
-    ls.readlines("\x0", chomp: true).reject do |f|
-      (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
-    end
+  output, = Open3.capture2("git", "ls-files", "-z", chdir: __dir__)
+  spec.files = output.split("\x0").reject do |f|
+    (f == gemspec) ||
+      f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
   end
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }

--- a/spec/no_comments/comment_detector_spec.rb
+++ b/spec/no_comments/comment_detector_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe NoComments::CommentDetector do
       expect(documentation_comment?("# @return [Integer]")).to be true
     end
 
+    it "detects comments preceding class definitions" do
+      expect(documentation_comment?("# My class", "class Foo")).to be true
+    end
+
+    it "detects nodoc comments" do
+      expect(documentation_comment?("# :nodoc:")).to be true
+    end
+
     it "returns false for non-documentation comments" do
       expect(documentation_comment?("# Just a comment")).to be false
       expect(documentation_comment?("# rubocop:disable all")).to be false

--- a/spec/no_comments/content_processor_spec.rb
+++ b/spec/no_comments/content_processor_spec.rb
@@ -407,6 +407,31 @@ RSpec.describe NoComments::ContentProcessor do
       end
     end
 
+    context "when the content has class documentation comments" do
+      let(:content) do
+        <<~RUBY
+          # This class does things
+          class MyClass
+          end
+        RUBY
+      end
+
+      it "preserves class documentation when option enabled" do
+        custom_processor = described_class.new(keep_doc_comments: true)
+        cleaned_content, _comments = custom_processor.process(content)
+        expect(cleaned_content).to eq(content)
+      end
+
+      it "removes class documentation by default" do
+        cleaned_content, _comments = processor.process(content)
+        expected = <<~RUBY
+          class MyClass
+          end
+        RUBY
+        expect(cleaned_content).to eq(expected)
+      end
+    end
+
     context "when the content has inline documentation comments" do
       let(:content) do
         <<~RUBY
@@ -435,6 +460,30 @@ RSpec.describe NoComments::ContentProcessor do
                                  [1, "# @param name [String]"],
                                  [2, "# @return [void]"]
                                ])
+      end
+    end
+
+    context "when the content has nodoc comments" do
+      let(:content) do
+        <<~RUBY
+          class MyClass # :nodoc:
+          end
+        RUBY
+      end
+
+      it "preserves nodoc comments when option enabled" do
+        custom_processor = described_class.new(keep_doc_comments: true)
+        cleaned_content, = custom_processor.process(content)
+        expect(cleaned_content).to eq(content)
+      end
+
+      it "removes nodoc comments by default" do
+        cleaned_content, = processor.process(content)
+        expected = <<~RUBY
+          class MyClass
+          end
+        RUBY
+        expect(cleaned_content).to eq(expected)
       end
     end
   end

--- a/spec/no_comments/no_comments_cli_spec.rb
+++ b/spec/no_comments/no_comments_cli_spec.rb
@@ -99,6 +99,44 @@ RSpec.describe "no_comments CLI" do
       expect(stdout).to include("Audit completed successfully.\n")
       expect(stderr).to eq("")
     end
+
+    it "preserves class documentation with flag" do
+      File.write(temp_file, <<~RUBY)
+        # Description
+        class Foo
+        end
+      RUBY
+      command = "exe/no_comments -p #{temp_file} --keep-doc-comments"
+      stdout, stderr, status = Open3.capture3(command)
+      expect(status.success?).to be true
+      expect(stdout).to include("Cleaning completed successfully.\n")
+      expect(stderr).to eq("")
+      cleaned_content = File.read(temp_file)
+      expected_content = <<~RUBY
+        # Description
+        class Foo
+        end
+      RUBY
+      expect(cleaned_content).to eq(expected_content)
+    end
+
+    it "handles nodoc comments" do
+      File.write(temp_file, <<~RUBY)
+        class Foo # :nodoc:
+        end
+      RUBY
+      command = "exe/no_comments -p #{temp_file} --keep-doc-comments"
+      stdout, stderr, status = Open3.capture3(command)
+      expect(status.success?).to be true
+      expect(stdout).to include("Cleaning completed successfully.\n")
+      expect(stderr).to eq("")
+      cleaned_content = File.read(temp_file)
+      expected_content = <<~RUBY
+        class Foo # :nodoc:
+        end
+      RUBY
+      expect(cleaned_content).to eq(expected_content)
+    end
   end
 
   describe "when directory is passed as an argument" do

--- a/spec/no_comments/remover_spec.rb
+++ b/spec/no_comments/remover_spec.rb
@@ -276,6 +276,64 @@ RSpec.describe NoComments::Remover do
       end
     end
 
+    context "when the file contains class documentation comments" do
+      it "removes them by default" do
+        original_code = <<~RUBY
+          # Documentation
+          class Test
+          end
+        RUBY
+        expected_code = <<~RUBY
+          class Test
+          end
+        RUBY
+        File.write(temp_file, original_code)
+        described_class.clean(temp_file)
+        cleaned_code = File.read(temp_file)
+        expect(cleaned_code).to eq(expected_code)
+      end
+
+      it "preserves them when keep_doc_comments is true" do
+        original_code = <<~RUBY
+          # Documentation
+          class Test
+          end
+        RUBY
+        File.write(temp_file, original_code)
+        described_class.clean(temp_file, keep_doc_comments: true)
+        cleaned_code = File.read(temp_file)
+        expect(cleaned_code).to eq(original_code)
+      end
+    end
+
+    context "when the file contains nodoc comments" do
+      it "removes them by default" do
+        original_code = <<~RUBY
+          class Test # :nodoc:
+          end
+        RUBY
+        expected_code = <<~RUBY
+          class Test
+          end
+        RUBY
+        File.write(temp_file, original_code)
+        described_class.clean(temp_file)
+        cleaned_code = File.read(temp_file)
+        expect(cleaned_code).to eq(expected_code)
+      end
+
+      it "preserves them when keep_doc_comments is true" do
+        original_code = <<~RUBY
+          class Test # :nodoc:
+          end
+        RUBY
+        File.write(temp_file, original_code)
+        described_class.clean(temp_file, keep_doc_comments: true)
+        cleaned_code = File.read(temp_file)
+        expect(cleaned_code).to eq(original_code)
+      end
+    end
+
     context "when the file contains multi-line comments" do
       it "removes the multi-line comments" do
         original_code = <<~RUBY


### PR DESCRIPTION
## Summary
- broaden detection of documentation comments
- preserve RuboCop Style/Documentation comments
- support :nodoc: and class/module docs
- test new behavior in core components and CLI

## Testing
- `bundle exec rspec`
- `bundle exec bundler-audit --update`
- `bundle exec rubocop --parallel`


------
https://chatgpt.com/codex/tasks/task_e_684d6e7c8f008333ad3de456b810a9c0